### PR TITLE
Add using for some types to work around compiler crash SR70253

### DIFF
--- a/firestore/src/include/firebase/firestore/map_field_value.h
+++ b/firestore/src/include/firebase/firestore/map_field_value.h
@@ -31,6 +31,15 @@ using MapFieldValue = std::unordered_map<std::string, FieldValue>;
 /** @brief A map of `FieldValue`s indexed by field paths. */
 using MapFieldPathValue = std::unordered_map<FieldPath, FieldValue>;
 
+#if defined(__swift__)
+// Reference the following types so that they are included in the CXX
+// module. A workaround for deserialization cross reference compiler
+// crashes https://github.com/apple/swift/issues/70253
+using FieldValueVector = std::vector<FieldValue>;
+using FieldValueVectorConstIterator = std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<FieldValue>>>;
+using StringVectorConstIterator = std::vector<std::string>::const_iterator;
+#endif
+
 }  // namespace firestore
 }  // namespace firebase
 


### PR DESCRIPTION
### Description

Reference some types so that they are included in the CXX module.

### Testing

Built Arc with cmake in debug mode. 

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable. WIN-971
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***


