### PR TITLE
Update bcny-firebase.yml

### DIFF
--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -160,6 +160,7 @@ jobs:
               <file src="`$BUILDROOT`$\usr\libs\windows\firebase_auth.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firebase_firestore.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firebase_rest_lib.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\firebase_util.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firestore_core.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firestore_nanopb.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firestore_protos_nanopb.lib" target="lib" />


### PR DESCRIPTION
Add missing `firebase_util.lib` to the packaging.  Thanks to @jeffdav for identifying the missing library.