### PR TITLE
Override build settings to specify /Z7 instead of /Zi for embedded PDBs in the BCNY windows build

### DIFF
--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 1
           path: ${{ github.workspace }}/SourceCache/firebase-cpp-sdk
-          ref: refs/heads/eng/z7build
+          ref: refs/heads/compnerd/swift
           repository: thebrowsercompany/firebase-cpp-sdk
 
       - uses: compnerd/gha-setup-vsdevenv@main

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 1
           path: ${{ github.workspace }}/SourceCache/firebase-cpp-sdk
-          ref: refs/heads/compnerd/swift
+          ref: refs/heads/eng/z7build
           repository: thebrowsercompany/firebase-cpp-sdk
 
       - uses: compnerd/gha-setup-vsdevenv@main
@@ -56,7 +56,40 @@ jobs:
       - name: Build flatc
         run: cmake --build ${{ github.workspace }}/BinaryCache/flatbuffers --config Release --target flatc
 
+      - name: Adjust cmake build settings for debugging
+        run: powershell ${{ github.workspace }}/SourceCache/firebase-cpp-sdk/build_scripts/windows/fix_cmake_debugflags.ps1 ${{ github.workspace }}/SourceCache/firebase-cpp-sdk/CMakeLists.txt
+
       - name: Configure firebase
+        run:
+          cmake -B ${{ github.workspace }}/BinaryCache/firebase `
+                -D BUILD_SHARED_LIBS=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/firebase/usr `
+                -G "Visual Studio 17 2022" `
+                -A ${{ matrix.platform }} `
+                -S ${{ github.workspace }}/SourceCache/firebase-cpp-sdk `
+                -D FLATBUFFERS_BUILD_FLATC=NO `
+                -D FIREBASE_CPP_BUILD_PACKAGE=YES `
+                -D FIREBASE_GITHUB_ACTION_BUILD=YES `
+                -D FIREBASE_INCLUDE_LIBRARY_DEFAULT=OFF `
+                -D FIREBASE_INCLUDE_AUTH=YES `
+                -D FIREBASE_INCLUDE_FIRESTORE=YES `
+                -D FIREBASE_USE_BORINGSSL=YES `
+                -D MSVC_RUNTIME_LIBRARY_STATIC=NO `
+                -D CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
+                -D FIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=${{ steps.python.outputs.python-path }} `
+                -D FLATBUFFERS_FLATC_EXECUTABLE=${{ github.workspace }}/BinaryCache/flatbuffers/Release/flatc.exe
+
+      - name: Adjust external project build settings for debugging
+        run: |
+          $names = Get-ChildItem -Path "${{ github.workspace }}/BinaryCache/firebase" -File -Recurse -Filter CMakeLists.txt
+          foreach ($name in $names) {
+            $fullName = $name.FullName
+            powershell ${{ github.workspace }}/SourceCache/firebase-cpp-sdk/build_scripts/windows/fix_cmake_debugflags.ps1 $fullName
+            Write-Host "... fixed up debug options for ${fullName}"
+          }
+
+      - name: Configure firebase after build setting adjustments
         run:
           cmake -B ${{ github.workspace }}/BinaryCache/firebase `
                 -D BUILD_SHARED_LIBS=NO `

--- a/build_scripts/windows/fix_cmake_debugflags.ps1
+++ b/build_scripts/windows/fix_cmake_debugflags.ps1
@@ -1,0 +1,33 @@
+# Path to the CMakeLists.txt file
+$filePath = $args[0]
+
+# Lines to add after the line starting with "cmake_minimum_required"
+$newLines = @(
+    'string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")',
+    'string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")',
+    'string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")',
+    'string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")'
+)
+
+# Read the content of the file
+$content = Get-Content -Path $filePath
+
+# New content holder
+$newContent = @()
+
+# Flag to check if lines are added
+$linesAdded = $false
+
+foreach ($line in $content) {
+    # Add the current line to new content
+    $newContent += $line
+
+    # Check if the line starts with "cmake_minimum_required" and add new lines after it
+    if ($line -match '^cmake_minimum_required' -and -not $linesAdded) {
+        $newContent += $newLines
+        $linesAdded = $true
+    }
+}
+
+# Write the new content back to the file
+$newContent | Set-Content -Path $filePath


### PR DESCRIPTION
### Description
This change modifies the way the Nuget package builds for windows. It forces the C++ and C flags to specify `/Z7` instead of `/Zi` for MSVC, which embeds the debug info PDBs into the object files.

### Testing
Build the SDK and used these libraries to build a downstream project.
