### PR TITLE
[cmake] Target AXV2 ISA when building for AMD64

### DIFF
--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -76,8 +76,8 @@ jobs:
                 -D FIREBASE_INCLUDE_FIRESTORE=YES `
                 -D FIREBASE_USE_BORINGSSL=YES `
                 -D MSVC_RUNTIME_LIBRARY_STATIC=NO `
-                -D CMAKE_C_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc-"`
-                -D CMAKE_CXX_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc-" `
+                -D CMAKE_C_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc- /arch:AVX2"`
+                -D CMAKE_CXX_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc- /arch:AVX2" `
                 -D CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
                 -D FIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=${{ steps.python.outputs.python-path }} `
                 -D FLATBUFFERS_FLATC_EXECUTABLE=${{ github.workspace }}/BinaryCache/flatbuffers/Release/flatc.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,15 @@ set(FIREBASE_GEN_FILE_DIR ${CMAKE_BINARY_DIR}/generated)
 # Directory for any shared scripts.
 set(FIREBASE_SCRIPT_DIR ${CMAKE_CURRENT_LIST_DIR})
 
+# This must be called before checking CMAKE_SYSTEM_PROCESSOR below.
+# Otherwise it is unset.
+project(FirebaseCppSdk)
+
 if (MSVC)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES AMD64)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:"/arch:AVX2">)
+  endif()
+
   if (MSVC_RUNTIME_LIBRARY_STATIC)
     add_compile_options(
       $<$<CONFIG:>:/MT>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,15 +185,7 @@ set(FIREBASE_GEN_FILE_DIR ${CMAKE_BINARY_DIR}/generated)
 # Directory for any shared scripts.
 set(FIREBASE_SCRIPT_DIR ${CMAKE_CURRENT_LIST_DIR})
 
-# This must be called before checking CMAKE_SYSTEM_PROCESSOR below.
-# Otherwise it is unset.
-project(FirebaseCppSdk)
-
 if (MSVC)
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES AMD64)
-    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:"/arch:AVX2">)
-  endif()
-
   if (MSVC_RUNTIME_LIBRARY_STATIC)
     add_compile_options(
       $<$<CONFIG:>:/MT>


### PR DESCRIPTION
### Description

Targeting AXV2 is the closest we can get to targeting Haswell when compiling with msvc. See DEVIN-1142 for more context.

### Type of Change

Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
