### PR TITLE
Update map_field_value.h

### DIFF
--- a/firestore/src/include/firebase/firestore/map_field_value.h
+++ b/firestore/src/include/firebase/firestore/map_field_value.h
@@ -36,7 +36,11 @@ using MapFieldPathValue = std::unordered_map<FieldPath, FieldValue>;
 // module. A workaround for deserialization cross reference compiler
 // crashes https://github.com/apple/swift/issues/70253
 using FieldValueVector = std::vector<FieldValue>;
+#if defined(_WIN32)
 using FieldValueVectorConstIterator = std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<FieldValue>>>;
+#else
+using FieldValueVectorConstIterator = std::vector<FieldValue>::const_iterator;
+#endif
 using StringVectorConstIterator = std::vector<std::string>::const_iterator;
 #endif
 


### PR DESCRIPTION
Use `std::vector<_>::const_iterator` for the typealias to allow building with different C++ standard libraries. This is required to enable the use of the package for Android platforms.