### PR TITLE
Disable C++ exception handling for windows builds

### DIFF
--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -76,8 +76,8 @@ jobs:
                 -D FIREBASE_INCLUDE_FIRESTORE=YES `
                 -D FIREBASE_USE_BORINGSSL=YES `
                 -D MSVC_RUNTIME_LIBRARY_STATIC=NO `
-                -D CMAKE_C_FLAGS="/EHsc" `
-                -D CMAKE_CXX_FLAGS="/EHsc" `
+                -D CMAKE_C_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc-"`
+                -D CMAKE_CXX_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc-" `
                 -D CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
                 -D FIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=${{ steps.python.outputs.python-path }} `
                 -D FLATBUFFERS_FLATC_EXECUTABLE=${{ github.workspace }}/BinaryCache/flatbuffers/Release/flatc.exe

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -76,6 +76,8 @@ jobs:
                 -D FIREBASE_INCLUDE_FIRESTORE=YES `
                 -D FIREBASE_USE_BORINGSSL=YES `
                 -D MSVC_RUNTIME_LIBRARY_STATIC=NO `
+                -D CMAKE_C_FLAGS="/EHsc" `
+                -D CMAKE_CXX_FLAGS="/EHsc" `
                 -D CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
                 -D FIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=${{ steps.python.outputs.python-path }} `
                 -D FLATBUFFERS_FLATC_EXECUTABLE=${{ github.workspace }}/BinaryCache/flatbuffers/Release/flatc.exe


### PR DESCRIPTION
This should fix an error in the windows CI builds:

```
MSBuild version 17.9.8+b34f75857 for .NET Framework
2024-03-29T16:16:13.8972368Z 
2024-03-29T16:16:14.1874711Z   1>Checking Build System
2024-03-29T16:16:14.3859793Z   Building Custom Rule D:/a/firebase-cpp-sdk/firebase-cpp-sdk/BinaryCache/firebase/external/src/flatbuffers/CMakeLists.txt
2024-03-29T16:16:14.5018507Z   idl_parser.cpp
2024-03-29T16:16:15.3000069Z C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vector(1041,13): error C2220: the following warning is treated as an error [D:\a\firebase-cpp-sdk\firebase-cpp-sdk\BinaryCache\firebase\external\src\flatbuffers-build\flatbuffers.vcxproj]
2024-03-29T16:16:15.3018139Z   (compiling source file '../flatbuffers/src/idl_parser.cpp')
2024-03-29T16:16:15.3018873Z   
2024-03-29T16:16:15.3405081Z C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vector(1041,13): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc [D:\a\firebase-cpp-sdk\firebase-cpp-sdk\BinaryCache\firebase\external\src\flatbuffers-build\flatbuffers.vcxproj]
```