### PR TITLE
Build storage and functions

### DIFF
--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -224,6 +224,8 @@ jobs:
               <file src="`$BUILDROOT`$\usr\libs\windows\firebase_app.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firebase_auth.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firebase_firestore.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\firebase_functions.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\firebase_storage.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firebase_rest_lib.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firestore_core.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firestore_nanopb.lib" target="lib" />

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -293,7 +293,6 @@ jobs:
               <file src="`$BUILDROOT`$\usr\libs\windows\re2.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\snappy.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\ssl.lib" target="lib" />
-              <file src="`$BUILDROOT`$\usr\libs\windows\upb.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\uv_a.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\zlibstatic.lib" target="lib" />
             </files>

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -77,6 +77,8 @@ jobs:
                 -D FIREBASE_INCLUDE_LIBRARY_DEFAULT=OFF `
                 -D FIREBASE_INCLUDE_AUTH=YES `
                 -D FIREBASE_INCLUDE_FIRESTORE=YES `
+                -D FIREBASE_INCLUDE_FUNCTIONS=YES `
+                -D FIREBASE_INCLUDE_STORAGE=YES `
                 -D FIREBASE_USE_BORINGSSL=YES `
                 -D MSVC_RUNTIME_LIBRARY_STATIC=NO `
                 -D CMAKE_C_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc-"`
@@ -110,6 +112,8 @@ jobs:
                 -D FIREBASE_INCLUDE_LIBRARY_DEFAULT=OFF `
                 -D FIREBASE_INCLUDE_AUTH=YES `
                 -D FIREBASE_INCLUDE_FIRESTORE=YES `
+                -D FIREBASE_INCLUDE_FUNCTIONS=YES `
+                -D FIREBASE_INCLUDE_STORAGE=YES `
                 -D FIREBASE_USE_BORINGSSL=YES `
                 -D MSVC_RUNTIME_LIBRARY_STATIC=NO `
                 -D CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
@@ -168,8 +172,10 @@ jobs:
               <file src="`$BUILDROOT`$\usr\include\firebase\app.h" target="include/firebase" />
               <file src="`$BUILDROOT`$\usr\include\firebase\auth.h" target="include/firebase" />
               <file src="`$BUILDROOT`$\usr\include\firebase\firestore.h" target="include/firebase" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\functions.h" target="include/firebase" />
               <file src="`$BUILDROOT`$\usr\include\firebase\future.h" target="include/firebase" />
               <file src="`$BUILDROOT`$\usr\include\firebase\log.h" target="include/firebase" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\storage.h" target="include/firebase" />
               <file src="`$BUILDROOT`$\usr\include\firebase\util.h" target="include/firebase" />
               <file src="`$BUILDROOT`$\usr\include\firebase\variant.h" target="include/firebase" />
               <file src="`$BUILDROOT`$\usr\include\firebase\auth\credential.h" target="include/firebase/auth" />
@@ -200,6 +206,14 @@ jobs:
               <file src="`$BUILDROOT`$\usr\include\firebase\firestore\transaction.h" target="include/firebase/firestore" />
               <file src="`$BUILDROOT`$\usr\include\firebase\firestore\transaction_options.h" target="include/firebase/firestore" />
               <file src="`$BUILDROOT`$\usr\include\firebase\firestore\write_batch.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\functions\callable_reference.h" target="include/firebase/functions" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\functions\callable_result.h" target="include/firebase/functions" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\functions\common.h" target="include/firebase/functions" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\storage\common.h" target="include/firebase/storage" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\storage\controller.h" target="include/firebase/storage" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\storage\listener.h" target="include/firebase/storage" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\storage\metadata.h" target="include/firebase/storage" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\storage\storage_reference.h" target="include/firebase/storage" />
               <file src="`$BUILDROOT`$\usr\include\firebase\internal\common.h" target="include/firebase/internal" />
               <file src="`$BUILDROOT`$\usr\include\firebase\internal\future_impl.h" target="include/firebase/internal" />
               <file src="`$BUILDROOT`$\usr\include\firebase\internal\mutex.h" target="include/firebase/internal" />


### PR DESCRIPTION
Changes:
- Adds `FIREBASE_INCLUDE_{FUNCTIONS,STORAGE}` defines to the `cmake` build.
- Includes corresponding header files in the nuget package.
- Includes generated libs in the nuget package.
- Removes `upb.lib` which appears to no longer be generated.