### PR TITLE
Revert "[cmake] Target AXV2 ISA when building for AMD64 (#23)"

### DIFF
--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -76,8 +76,8 @@ jobs:
                 -D FIREBASE_INCLUDE_FIRESTORE=YES `
                 -D FIREBASE_USE_BORINGSSL=YES `
                 -D MSVC_RUNTIME_LIBRARY_STATIC=NO `
-                -D CMAKE_C_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc- /arch:AVX2"`
-                -D CMAKE_CXX_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc- /arch:AVX2" `
+                -D CMAKE_C_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc-"`
+                -D CMAKE_CXX_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc-" `
                 -D CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
                 -D FIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=${{ steps.python.outputs.python-path }} `
                 -D FLATBUFFERS_FLATC_EXECUTABLE=${{ github.workspace }}/BinaryCache/flatbuffers/Release/flatc.exe


### PR DESCRIPTION
### Description

Passing `/arch:AVX2` to MSVC breaks the libcurl build in a strange way. It causes the error at the end curl's [nonblock.c](https://github.com/curl/curl/blob/master/lib/nonblock.c) file to throw, indicating our build is missing one of the defines in that file.  This change is being reverted until we can diagnose.

[replace this line]: # (Describe your changes in detail.)
***
### Testing

- https://github.com/thebrowsercompany/firebase-cpp-sdk/actions/runs/8993073149
- https://github.com/thebrowsercompany/firebase-cpp-sdk/actions/runs/8993056021

[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
- [x] Bug fix.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***