### PR TITLE
Trigger the firebase workflow on pull requests

### DIFF
--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -1,6 +1,7 @@
 name: firebase
 
 on:
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -28,7 +29,6 @@ jobs:
         with:
           fetch-depth: 1
           path: ${{ github.workspace }}/SourceCache/firebase-cpp-sdk
-          ref: refs/heads/compnerd/swift
           repository: thebrowsercompany/firebase-cpp-sdk
 
       - uses: compnerd/gha-setup-vsdevenv@main
@@ -301,11 +301,13 @@ jobs:
           nuget pack -Properties BUILDROOT=${{ github.workspace }}\BuildRoot\Library\firebase -Suffix (git -C ${{ github.workspace }}/SourceCache/firebase-cpp-sdk log -1 --format=%h) firebase.nuspec
         shell: pwsh
       - uses: actions/upload-artifact@v3
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
           name: windows-${{ matrix.arch }}.nupkg
           path: com.google.firebase.windows.${{ matrix.arch }}.*.nupkg
 
       - name: Publish NuGet Packages
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           NUGET_SOURCE_NAME: TheBrowserCompany
           NUGET_SOURCE_URL: https://nuget.pkg.github.com/thebrowsercompany/index.json


### PR DESCRIPTION
### Description

Removes a footgun where the PR author may trigger this workflow incorrectly when testing a PR.

### Changes

- Make sure this workflow clones the PR branch's version of the code by removing the hardcoded reference to `compnerd/swift`
- Add `on.pull_request` event trigger
- Skip nuget package actions/upload step if the event is workflow_dispatch.
- Skip nuget package publish step if the event is workflow_dispatch.

### Testing

The workflow is now running as part of this PR's presubmit

### Type of Change

- [ ] Bug fix. Add the issue # below if applicable.
- [x] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***
