### PR TITLE
Explicitly set HAVE_IOCTLSOCKET_FIONBIO=1

### DIFF
--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Adjust cmake build settings for debugging
         run: powershell ${{ github.workspace }}/SourceCache/firebase-cpp-sdk/build_scripts/windows/fix_cmake_debugflags.ps1 ${{ github.workspace }}/SourceCache/firebase-cpp-sdk/CMakeLists.txt
 
+      # For curl we set '-D HAVE_IOCTLSOCKET_FIONBIO=1'. This should automatically be set to 1 by
+      # https://github.com/curl/curl/blob/60580f9f214869b501ba0caaa5a6bf335e6aee1d/CMake/Platforms/WindowsCache.cmake
+      # but this is not what we observe in CI.
       - name: Configure firebase
         run:
           cmake -B ${{ github.workspace }}/BinaryCache/firebase `
@@ -79,6 +82,7 @@ jobs:
                 -D CMAKE_C_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc-"`
                 -D CMAKE_CXX_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc-" `
                 -D CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
+                -D HAVE_IOCTLSOCKET_FIONBIO=1 `
                 -D FIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=${{ steps.python.outputs.python-path }} `
                 -D FLATBUFFERS_FLATC_EXECUTABLE=${{ github.workspace }}/BinaryCache/flatbuffers/Release/flatc.exe
 


### PR DESCRIPTION
### Description

Adds a new CMake `HAVE_IOCTLSOCKET_FIONBIO` define that allows `curl` to build [(link to definition)](https://github.com/curl/curl/blob/master/lib/nonblock.c#L63).  When this is not set, we hit the "no non-blocking..." error at the bottom of that file.

This is not a permanent solution but the build has been broken for several weeks and this should unblock us while we debug. It is a workaround because this define should be set automatically when building curl and this does not seem to be an issue for the upstream `firebase/firebase-cpp-sdk` builds which means we have a bug somewhere.

This should also help us roll out avx2 support again.

### Testing

See workflow runs at:
https://github.com/thebrowsercompany/firebase-cpp-sdk/actions?query=branch:kendal/sync-this-fork

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***
