### PR TITLE
Print built libraries before packaging the SDK

### DIFF
--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -154,6 +154,9 @@ jobs:
           gh release upload "$Date.$Release" firebase-windows-${{ matrix.arch }}.zip -R ${{ github.repository }}
           gh release upload "$Date.$Release" firebase-windows-${{ matrix.arch }}.zip.sha256 -R ${{ github.repository }}
 
+      - name: Print built libraries
+        run: Get-ChildItem -Recurse -Name -Path ${{ github.workspace }}\BuildRoot\Library\firebase -Include *.lib
+
       - name: Package firebase-cpp-sdk
         run: |
           @"


### PR DESCRIPTION
### Description

Show the paths to all libraries that were built for easier debugging.

You can also download the workflow artifact at the end of the run but it's several GB in size and printing to the logs is more convenient.