### PR TITLE
Add missing filter.h header to Nuget package

### DIFF
--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -193,6 +193,7 @@ jobs:
               <file src="`$BUILDROOT`$\usr\include\firebase\firestore\document_snapshot.h" target="include/firebase/firestore" />
               <file src="`$BUILDROOT`$\usr\include\firebase\firestore\field_path.h" target="include/firebase/firestore" />
               <file src="`$BUILDROOT`$\usr\include\firebase\firestore\field_value.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\filter.h" target="include/firebase/firestore" />
               <file src="`$BUILDROOT`$\usr\include\firebase\firestore\firestore_errors.h" target="include/firebase/firestore" />
               <file src="`$BUILDROOT`$\usr\include\firebase\firestore\geo_point.h" target="include/firebase/firestore" />
               <file src="`$BUILDROOT`$\usr\include\firebase\firestore\listener_registration.h" target="include/firebase/firestore" />


### PR DESCRIPTION
This was added at the end of last year here:
https://github.com/firebase/firebase-cpp-sdk/pull/1453