### PR TITLE
Reland changes to target avx2

### DIFF
--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -81,8 +81,8 @@ jobs:
                 -D FIREBASE_INCLUDE_STORAGE=YES `
                 -D FIREBASE_USE_BORINGSSL=YES `
                 -D MSVC_RUNTIME_LIBRARY_STATIC=NO `
-                -D CMAKE_C_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc-"`
-                -D CMAKE_CXX_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc-" `
+                -D CMAKE_C_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc- /arch:AVX2" `
+                -D CMAKE_CXX_FLAGS="/D_HAS_EXCEPTIONS=0 /EHsc- /arch:AVX2" `
                 -D CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
                 -D HAVE_IOCTLSOCKET_FIONBIO=1 `
                 -D FIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=${{ steps.python.outputs.python-path }} `


### PR DESCRIPTION
### Description

Add build flags to target avx2.

This was previously reverted because it was falsely identified as the cause of a bcny-firebase.yml build breakage - the true culprit was a buggy flag set in curl's cmake configuration which was fixed in https://github.com/thebrowsercompany/firebase-cpp-sdk/pull/30

### Testing
 
Presubmit

### Type of Change

- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
