### PR TITLE
Periodically rebase firebase-cpp-sdk with upstream

### DIFF
--- a/.github/workflows/cron-sync-with-upstream.yml
+++ b/.github/workflows/cron-sync-with-upstream.yml
@@ -1,0 +1,19 @@
+name: Cron - Sync with upstream
+
+on:
+  schedule:
+    # Every day 8:00 am UTC
+    - cron: '0 8 * * *'
+
+  workflow_dispatch:
+
+jobs:
+  sync_with_upstream:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: thebrowsercompany/gha-sync-fork@2374ecc08280ab56d3a6161d0cede45ebf95cd61
+        with:
+          fork_repo: thebrowsercompany/firebase-cpp-sdk
+          fork_branch: compnerd/swift
+          upstream_repo: firebase/firebase-cpp-sdk
+          upstream_branch: main


### PR DESCRIPTION
### Description

This workflow runs `thebrowsercompany/gha-sync-fork` at 8 am every day.

It can also be triggered manually using:

```
gh workflow run 'cron-sync-with-upstream.yml' -R thebrowsercompany/firebase-cpp-sdk
```

Or by clicking the "Sync this Fork" button in the GitHub UI.

### Testing

See this workflow run: https://github.com/thebrowsercompany/firebase-cpp-sdk/actions/runs/9104534949 
