### PR TITLE
Skip publishing steps if triggered by a PR

### DIFF
--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -143,6 +143,7 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/firebase
 
       - name: Create Release
+        if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -326,13 +327,13 @@ jobs:
           nuget pack -Properties BUILDROOT=${{ github.workspace }}\BuildRoot\Library\firebase -Suffix (git -C ${{ github.workspace }}/SourceCache/firebase-cpp-sdk log -1 --format=%h) firebase.nuspec
         shell: pwsh
       - uses: actions/upload-artifact@v3
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: github.event_name != 'pull_request'
         with:
           name: windows-${{ matrix.arch }}.nupkg
           path: com.google.firebase.windows.${{ matrix.arch }}.*.nupkg
 
       - name: Publish NuGet Packages
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: github.event_name != 'pull_request'
         env:
           NUGET_SOURCE_NAME: TheBrowserCompany
           NUGET_SOURCE_URL: https://nuget.pkg.github.com/thebrowsercompany/index.json
@@ -452,6 +453,7 @@ jobs:
 
   release_android:
     needs: [android]
+    if: github.event_name != 'pull_request'
     runs-on: windows-latest
     steps:
       - name: Download firebase-android-arm64-v8a artifact


### PR DESCRIPTION
## Description

We recently created an extra release by mistake because we didn't have this guard:
  - https://github.com/thebrowsercompany/firebase-cpp-sdk/releases/tag/20240528.2
  - https://github.com/thebrowsercompany/firebase-cpp-sdk/releases/tag/20240528.1

## Testing

- See workflow runs on this PR.