### PR TITLE
Add a firestore copy constructor for Android too

### DIFF
--- a/firestore/src/common/firestore_swift.cc
+++ b/firestore/src/common/firestore_swift.cc
@@ -17,7 +17,7 @@
 #define __swift__ 50000
 #include "firestore/src/include/firebase/firestore.h"
 
-#if FIREBASE_PLATFORM_WINDOWS
+#if FIREBASE_PLATFORM_WINDOWS || FIREBASE_PLATFORM_ANDROID
 namespace firebase {
 namespace firestore {
 Firestore::Firestore(const Firestore &) noexcept = default;

--- a/firestore/src/include/firebase/firestore.h
+++ b/firestore/src/include/firebase/firestore.h
@@ -196,7 +196,7 @@ class Firestore {
    * Firestore::GetInstance().
    */
 #if defined(__swift__)
-#if FIREBASE_PLATFORM_WINDOWS
+#if FIREBASE_PLATFORM_WINDOWS || FIREBASE_PLATFORM_ANDROID
   Firestore(const Firestore& src) noexcept;
 #else
   Firestore(const Firestore& src) = delete;


### PR DESCRIPTION

This is needed to make `Firestore` importable in Swift for Android.