### PR TITLE
auth: add copy constructor for `firebase::auth::Auth` on Android

### DIFF
--- a/auth/src/auth_swift.cc
+++ b/auth/src/auth_swift.cc
@@ -17,7 +17,7 @@
 #define __swift__ 50000
 #include "auth/src/include/firebase/auth.h"
 
-#if FIREBASE_PLATFORM_WINDOWS
+#if FIREBASE_PLATFORM_WINDOWS || FIREBASE_PLATFORM_ANDROID
 namespace firebase {
 namespace auth {
 Auth::Auth(const Auth &) noexcept = default;

--- a/auth/src/include/firebase/auth.h
+++ b/auth/src/include/firebase/auth.h
@@ -148,7 +148,7 @@ class Auth {
   ~Auth();
 
 #if defined(__swift__)
-#if FIREBASE_PLATFORM_WINDOWS
+#if FIREBASE_PLATFORM_WINDOWS || FIREBASE_PLATFORM_ANDROID
   // TODO(apple/swift#67288) support trivial C++ types with non-trivial dtors
   Auth(const Auth&) noexcept;
 #endif


### PR DESCRIPTION
Add the copy constructor on Android as well to ensure that the type is imported properly by the clang importer when bridging to Swift.