### PR TITLE
Copy over headers we use for firebase for the android distribution

### DIFF
--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -475,6 +475,29 @@ jobs:
             cp "$file" "$destination_dir"
             echo "Copied: $file"
           done < <(find $source -type f -name "*.a")
+          echo "Copying header files ..."
+          header_destination_dir=${{ github.workspace }}/BuildRoot/Library/firebase/usr/include/firebase
+          firebase_dir=${{ github.workspace }}/SourceCache/firebase-cpp-sdk
+          mkdir -p $header_destination_dir
+          cp ${firebase_dir}/app/src/include/firebase/app.h ${header_destination_dir}
+          cp ${firebase_dir}/app/src/include/firebase/future.h ${header_destination_dir}
+          cp ${firebase_dir}/app/src/include/firebase/log.h ${header_destination_dir}
+          cp ${firebase_dir}/app/src/include/firebase/util.h ${header_destination_dir}
+          cp ${firebase_dir}/app/src/include/firebase/variant.h ${header_destination_dir}
+          mkdir -p $header_destination_dir/internal
+          cp ${firebase_dir}/app/src/include/firebase/internal/*.h ${header_destination_dir}/internal/
+          cp ${firebase_dir}/auth/src/include/firebase/auth.h ${header_destination_dir}
+          mkdir -p $header_destination_dir/auth
+          cp ${firebase_dir}/auth/src/include/firebase/auth/*.h ${header_destination_dir}/auth/
+          cp ${firebase_dir}/firestore/src/include/firebase/firestore.h ${header_destination_dir}
+          mkdir -p $header_destination_dir/firestore
+          cp ${firebase_dir}/firestore/src/include/firebase/firestore/*.h ${header_destination_dir}/firestore/
+          cp ${firebase_dir}/functions/src/include/firebase/functions.h ${header_destination_dir}
+          mkdir -p $header_destination_dir/functions
+          cp ${firebase_dir}/functions/src/include/firebase/functions/*.h ${header_destination_dir}/functions/
+          cp ${firebase_dir}/storage/src/include/firebase/storage.h ${header_destination_dir}
+          mkdir -p $header_destination_dir/storage
+          cp ${firebase_dir}/storage/src/include/firebase/storage/*.h ${header_destination_dir}/storage/
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -478,26 +478,39 @@ jobs:
           echo "Copying header files ..."
           header_destination_dir=${{ github.workspace }}/BuildRoot/Library/firebase/usr/include/firebase
           firebase_dir=${{ github.workspace }}/SourceCache/firebase-cpp-sdk
-          mkdir -p $header_destination_dir
-          cp ${firebase_dir}/app/src/include/firebase/app.h ${header_destination_dir}
-          cp ${firebase_dir}/app/src/include/firebase/future.h ${header_destination_dir}
-          cp ${firebase_dir}/app/src/include/firebase/log.h ${header_destination_dir}
-          cp ${firebase_dir}/app/src/include/firebase/util.h ${header_destination_dir}
-          cp ${firebase_dir}/app/src/include/firebase/variant.h ${header_destination_dir}
-          mkdir -p $header_destination_dir/internal
-          cp ${firebase_dir}/app/src/include/firebase/internal/*.h ${header_destination_dir}/internal/
-          cp ${firebase_dir}/auth/src/include/firebase/auth.h ${header_destination_dir}
-          mkdir -p $header_destination_dir/auth
-          cp ${firebase_dir}/auth/src/include/firebase/auth/*.h ${header_destination_dir}/auth/
-          cp ${firebase_dir}/firestore/src/include/firebase/firestore.h ${header_destination_dir}
-          mkdir -p $header_destination_dir/firestore
-          cp ${firebase_dir}/firestore/src/include/firebase/firestore/*.h ${header_destination_dir}/firestore/
-          cp ${firebase_dir}/functions/src/include/firebase/functions.h ${header_destination_dir}
-          mkdir -p $header_destination_dir/functions
-          cp ${firebase_dir}/functions/src/include/firebase/functions/*.h ${header_destination_dir}/functions/
-          cp ${firebase_dir}/storage/src/include/firebase/storage.h ${header_destination_dir}
-          mkdir -p $header_destination_dir/storage
-          cp ${firebase_dir}/storage/src/include/firebase/storage/*.h ${header_destination_dir}/storage/
+          mkdir -p $header_destination_dir \
+                   $header_destination_dir/internal \
+                   $header_destination_dir/auth \
+                   $header_destination_dir/firestore \
+                   $header_destination_dir/functions \
+                   $header_destination_dir/storage
+          for header in ${firebase_dir}/app/src/include/firebase/app.h \
+                        ${firebase_dir}/app/src/include/firebase/future.h \
+                        ${firebase_dir}/app/src/include/firebase/log.h \
+                        ${firebase_dir}/app/src/include/firebase/util.h \
+                        ${firebase_dir}/app/src/include/firebase/variant.h \
+                        ${firebase_dir}/auth/src/include/firebase/auth.h \
+                        ${firebase_dir}/firestore/src/include/firebase/firestore.h \
+                        ${firebase_dir}/functions/src/include/firebase/functions.h \
+                        ${firebase_dir}/storage/src/include/firebase/storage.h \
+                        ; do
+            cp $header ${header_destination_dir}
+          done
+          for header in ${firebase_dir}/app/src/include/firebase/internal/*.h; do
+            cp $header ${header_destination_dir}/internal/
+          done
+          for header in ${firebase_dir}/auth/src/include/firebase/auth/*.h; do
+            cp $header ${header_destination_dir}/auth/
+          done
+          for header in ${firebase_dir}/firestore/src/include/firebase/firestore/*.h; do
+            cp $header ${header_destination_dir}/firestore/
+          done
+          for header in ${firebase_dir}/functions/src/include/firebase/functions/*.h; do
+            cp $header ${header_destination_dir}/functions/
+          done
+          for header in ${firebase_dir}/storage/src/include/firebase/storage/*.h; do
+            cp $header ${header_destination_dir}/storage/
+          done
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
### Description
This changes the android firebase-cpp-sdk to also include the headers we use in the windows distribution in the android distribution as well.


***
### Testing
Manual workflow run.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

