### PR TITLE
Fix pure virtual call crash in `BackgroundTransportCurl` destructor

### DIFF
--- a/app/rest/transport_curl.cc
+++ b/app/rest/transport_curl.cc
@@ -394,19 +394,12 @@ BackgroundTransportCurl::~BackgroundTransportCurl() {
     request_header_ = nullptr;
   }
 
-  // If this is an asynchronous operation, MarkFailed() or MarkCompleted()
-  // could end up attempting to tear down TransportCurl so we signal
-  // completion here.
-  if (transport_curl_->is_async()) {
-    transport_curl_->SignalTransferComplete();
-    CompleteOperation();
-  } else {
-    // Synchronous operations need all data present in the response before
-    // Perform() returns so signal complete after MarkFailed() or
-    // MarkCompleted().
-    CompleteOperation();
-    transport_curl_->SignalTransferComplete();
-  }
+  // Complete the operation before signaling, so that request_/response_ are
+  // still valid when MarkCompleted()/MarkFailed() is called. Signaling first
+  // would allow the waiting thread to destroy the Request/Response objects
+  // before CompleteOperation() can use them, causing a pure virtual call crash.
+  CompleteOperation();
+  transport_curl_->SignalTransferComplete();
 }
 
 void BackgroundTransportCurl::CompleteOperation() {


### PR DESCRIPTION
Fixes a race condition in the curl HTTP transport destructor that causes a crash in Arc on Windows ([BROWSER-WIN-2SRG](https://thebrowsercompany.sentry.io/issues/5461771480/?project=4505954005876736)).

# Context

When an async HTTP request finishes, `~BackgroundTransportCurl` does two things: signals the calling thread that it can proceed (`SignalTransferComplete()`), and marks the request/response as completed (`CompleteOperation()`).

The problem is the async path does these in the wrong order. `SignalTransferComplete()` fires first, which wakes up the calling thread (blocked in `WaitForAllTransfersToComplete()`), and it immediately starts destroying the request and response objects. Then `CompleteOperation()` tries to call `MarkCompleted()` on an object that's mid-destruction; the vtable has already been rewound to the base class (`Transfer`) where `MarkCompleted()` is pure virtual, so we get a `_purecall` crash.

```cpp
// Before (async path):
transport_curl_->SignalTransferComplete();   // caller wakes up, starts destroying request/response
CompleteOperation();                         // calls MarkCompleted() mid-destruction — purecall

// After (both paths):
CompleteOperation();                         // mark request/response while they're still alive
transport_curl_->SignalTransferComplete();   // now safe to let the caller clean up
```

The synchronous path already had the correct order; the async path had a different order because of a concern (noted in a comment) that `CompleteOperation()` might somehow trigger destruction of the `TransportCurl` that owns the signal. But this isn't actually possible: `MarkCompleted()` and `MarkFailed()` just set a boolean flag (`completed_ = true`). And even if the `complete_` callback *did* somehow trigger `TransportCurl` destruction, `~TransportCurl` calls `WaitForAllTransfersToComplete()` which blocks on the semaphore, so it would deadlock waiting for the `SignalTransferComplete()` that hasn't happened yet.

# Changes

- Reorders the async path in `~BackgroundTransportCurl` to call `CompleteOperation()` before `SignalTransferComplete()`, matching the synchronous path.

# Testing

I can't repro this crash, so this fix is slightly speculative.